### PR TITLE
feat(auth): add role-based authorization for Admin and Student

### DIFF
--- a/MyStudentsApp/Controllers/AuthController.cs
+++ b/MyStudentsApp/Controllers/AuthController.cs
@@ -1,21 +1,24 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
+﻿using APIBusinessLayer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 using System.Text;
-using APIBusinessLayer;
 
 
 namespace StudentApi.Controllers
 {
     // This controller is responsible for authentication-related actions,
     // such as logging in and issuing JWT tokens.
+    [Authorize]
     [ApiController]
     [Route("api/[controller]")]
     public class AuthController : ControllerBase
     {
         // This endpoint handles user login.
         // It verifies credentials and returns a JWT token if login succeeds.
+        [AllowAnonymous]
         [HttpPost("login")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/MyStudentsApp/Controllers/PeopleApiController.cs
+++ b/MyStudentsApp/Controllers/PeopleApiController.cs
@@ -10,10 +10,11 @@ namespace MyStudentsApp.Controllers
     [ApiController]
     public class PeopleApiController : ControllerBase
     {
+        [Authorize(Roles = "Admin")]
         [HttpGet ("All", Name = "GetPeople")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-
         public ActionResult<IEnumerable<PersonDTO>> GetPeople()
         {
             List<PersonDTO> PeopleList = APIBusinessLayer.clsPerson.GetPeople();
@@ -25,11 +26,13 @@ namespace MyStudentsApp.Controllers
             return Ok(PeopleList);
         }
 
+
+        //I will finish the "GetPersonById" endpoint later. I need to implement Ownership Rules first.
         [HttpGet("{id}", Name = "GetPersonById")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-
         public ActionResult<PersonDTO> GetPersonById(int id)
         {
             if (id < 1)
@@ -50,11 +53,11 @@ namespace MyStudentsApp.Controllers
         }
 
 
-
+        [Authorize(Roles = "Admin")]
         [HttpPost(Name = "AddPerson")]
         [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-
         public ActionResult<PersonDTO>AddPerson([FromBody] PersonDTO newPersonDTO)
         {
             if (newPersonDTO == null || string.IsNullOrEmpty(newPersonDTO.FirstName) || string.IsNullOrEmpty(newPersonDTO.LastName) || newPersonDTO.BirthDate > DateTime.Now)
@@ -81,12 +84,12 @@ namespace MyStudentsApp.Controllers
             }
         }
 
-        
+        [Authorize(Roles = "Admin")]
         [HttpDelete("{id}" , Name = "DeletePersonById")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-
         public ActionResult DeletePersonById(int id)
         {
             if(id < 1)
@@ -104,12 +107,12 @@ namespace MyStudentsApp.Controllers
             }
         }
 
-
+        [Authorize(Roles = "Admin")]
         [HttpPut("{id}", Name = "UpdatePersonById")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-
         public ActionResult<PersonDTO> UpdatePersonById(int id, UpdatePersonDTO updatedPerson)
         {
             if (id < 1 || updatedPerson == null)

--- a/MyStudentsApp/Controllers/UsersAPIController.cs
+++ b/MyStudentsApp/Controllers/UsersAPIController.cs
@@ -12,8 +12,10 @@ namespace MyStudentsApp.Controllers
     [ApiController]
     public class UsersAPIController : ControllerBase
     {
+        [Authorize(Roles = "Admin")]
         [HttpGet("All", Name = "GetAllUsers")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public ActionResult<IEnumerable<UserDTO>> GetAllUsers()
         {
@@ -27,11 +29,12 @@ namespace MyStudentsApp.Controllers
 
             return Ok(UsersList);
         }
-        
+
+
+        //I will finish the "GetUserById" endpoint later. I need to implement Ownership Rules first.
         [HttpGet("{id}", Name = "GetUserById")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-
         public ActionResult<UserDTO> GetUserById(int id)
         {
             if (id < 1) return BadRequest($"Invalid ID {id}");
@@ -43,10 +46,11 @@ namespace MyStudentsApp.Controllers
             return Ok(user.UDTO);
         }
 
-        
+        [Authorize(Roles = "Admin")]
         [HttpPost(Name = "AddNewUser")]
-        [ProducesResponseType(StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public ActionResult<UserDTO> AddUser(CreateUserDTO createUserDto)
         {
@@ -86,9 +90,11 @@ namespace MyStudentsApp.Controllers
             return StatusCode(500, "Internal server error while creating user.");
         }
 
-       
+        [Authorize(Roles = "Admin")]
         [HttpPut("{id}", Name = "UpdateUserField")]
+        [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public ActionResult<UserDTO> UpdateUserField(int id, clsUser.enUpdateType updateType, [FromBody] string newValue)
         {
@@ -135,8 +141,11 @@ namespace MyStudentsApp.Controllers
             return StatusCode(500, "Update failed.");
         }
 
+
+        [Authorize(Roles = "Admin")]
         [HttpDelete("{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public ActionResult DeleteUser(int id)
         {

--- a/Students.BLL/AuthToken.cs
+++ b/Students.BLL/AuthToken.cs
@@ -2,8 +2,8 @@
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using BCrypt.Net;
 using System.Text;
+using BCrypt.Net;
 
 namespace APIBusinessLayer
 {


### PR DESCRIPTION
Description:
Overview:
I implemented Role-Based Role-Based Authorization

Key Changes:
Admin Permissions: Only Admins can now delete or update records.

General Access: Both Admins and Students can view basic data.

Note on "Get User Profile":
I skipped the endpoint for specific user data for now. I will implement Ownership Rules in the next task to ensure a student can only see their own profile.

How to test:

Log in as an Admin to get a token with admin rights.

Log in as a Student to test restricted access.